### PR TITLE
updated broadcast_struct.go

### DIFF
--- a/broadcast/broadcast_struct.go
+++ b/broadcast/broadcast_struct.go
@@ -62,6 +62,7 @@ func fetchAndBroadcast(ctx context.Context, op *hedge.Op, client *spanner.Client
 	}
 
 	// compare topicSub with lastBroadcasted to check if they are exactly the same
+	//ex: subscription was updated but reverted back to its original state before the next check
 	same := true
 	for key, subs := range topicSub {
 		if lastSubs, exists := (*lastBroadcasted)[key]; !exists || !equalStringSlices(subs, lastSubs) {
@@ -132,7 +133,7 @@ func StartDistributor(ctx context.Context, op *hedge.Op, client *spanner.Client)
 	}
 }
 
-// used to compare two string slices 
+// used to compare two string slices
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -161,4 +162,3 @@ func broadcastTopicSubStruct(op *hedge.Op, topicSub map[string][]string) {
 	log.Println("Leader: Broadcasted topic-subscription structure to all nodes")
 }
 */
-


### PR DESCRIPTION
1. Added lastBroadcasted to track previously broadcasted topic-subscription structures.
2. Prevented redundant broadcasts by checking if topicSub is identical to lastBroadcasted.
3. Implemented equalStringSlices to properly compare subscription lists.
4. Updated StartDistributor to correctly maintain lastBroadcasted across function calls.