### PR TITLE
updated broadcast_struct.go

### DIFF
--- a/broadcast/broadcast_struct.go
+++ b/broadcast/broadcast_struct.go
@@ -12,13 +12,20 @@ import (
 )
 
 // fetchAndBroadcast fetches updated topic-subscription data and broadcasts it if there are updates.
-func fetchAndBroadcast(ctx context.Context, op *hedge.Op, client *spanner.Client, lastChecked *time.Time, lastBroadcasted *map[string][]string) {
-	stmt := spanner.Statement{
-		SQL: `SELECT topic, ARRAY_AGG(name) AS subscriptions
-              FROM Subscriptions
-              WHERE updatedAt > @last_checked_time
-              GROUP BY topic`,
-		Params: map[string]interface{}{"last_checked_time": *lastChecked},
+func fetchAndBroadcast(ctx context.Context, op *hedge.Op, client *spanner.Client, lastChecked *time.Time, lastBroadcasted *map[string][]string, isStartup bool) {
+	stmt := spanner.Statement{}
+
+	if isStartup {
+		// on startup, fetch all topic-subscription mappings (ignore updatedAt)
+		stmt.SQL = `SELECT topic, ARRAY_AGG(name) AS subscriptions FROM Subscriptions GROUP BY topic`
+		log.Println("Leader: Startup detected. Broadcasting full topic-subscription data.")
+	} else {
+		// fetch only updated subscriptions
+		stmt.SQL = `SELECT topic, ARRAY_AGG(name) AS subscriptions 
+                    FROM Subscriptions 
+                    WHERE updatedAt > @last_checked_time 
+                    GROUP BY topic`
+		stmt.Params = map[string]interface{}{"last_checked_time": *lastChecked}
 	}
 
 	iter := client.Single().Query(ctx, stmt)
@@ -50,30 +57,14 @@ func fetchAndBroadcast(ctx context.Context, op *hedge.Op, client *spanner.Client
 		topicSub[topic] = subscriptions
 	}
 
-	// if there are no new updates, it will log
-	if len(topicSub) == 0 {
+	// if no updates and it's not startup, skip broadcasting
+	if len(topicSub) == 0 && !isStartup {
 		log.Println("Leader: No new updates, skipping broadcast.")
 		if len(*lastBroadcasted) > 0 {
 			log.Println("Leader: Subscription topic structure is still:", *lastBroadcasted)
 		} else {
 			log.Println("Leader: No previous topic-subscription structure available.")
 		}
-		return
-	}
-
-	// compare topicSub with lastBroadcasted to check if they are exactly the same
-	//ex: subscription was updated but reverted back to its original state before the next check
-	same := true
-	for key, subs := range topicSub {
-		if lastSubs, exists := (*lastBroadcasted)[key]; !exists || !equalStringSlices(subs, lastSubs) {
-			same = false
-			break
-		}
-	}
-
-	if same {
-		log.Println("Leader: No new updates, skipping broadcast.")
-		log.Println("Leader: Subscription topic structure is still:", *lastBroadcasted)
 		return
 	}
 
@@ -114,9 +105,12 @@ func fetchAndBroadcast(ctx context.Context, op *hedge.Op, client *spanner.Client
 // StartDistributor initializes the distributor that periodically checks for updates.
 func StartDistributor(ctx context.Context, op *hedge.Op, client *spanner.Client) {
 	lastChecked := time.Now().Add(-10 * time.Second)
-	lastBroadcasted := make(map[string][]string) // this will store the last known structure
+	lastBroadcasted := make(map[string][]string) // Stores the last known structure
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
+
+	// Perform an initial broadcast of all topic-subscription structures
+	fetchAndBroadcast(ctx, op, client, &lastChecked, &lastBroadcasted, true) // run during start up
 
 	for {
 		select {
@@ -125,40 +119,10 @@ func StartDistributor(ctx context.Context, op *hedge.Op, client *spanner.Client)
 		case <-ticker.C:
 			if hasLock, _ := op.HasLock(); hasLock {
 				log.Println("Leader: Processing updates...")
-				fetchAndBroadcast(ctx, op, client, &lastChecked, &lastBroadcasted)
+				fetchAndBroadcast(ctx, op, client, &lastChecked, &lastBroadcasted, false) //run if not startup
 			} else {
 				log.Println("Follower: No action needed.")
 			}
 		}
 	}
 }
-
-// used to compare two string slices
-func equalStringSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	exists := make(map[string]bool)
-	for _, val := range a {
-		exists[val] = true
-	}
-	for _, val := range b {
-		if !exists[val] {
-			return false
-		}
-	}
-	return true
-}
-
-// Leader broadcasts topic-subscription to all nodes (even if no changes/updates happened)
-/*
-func broadcastTopicSubStruct(op *hedge.Op, topicSub map[string][]string) {
-	data, err := json.Marshal(topicSub)
-	if err != nil {
-		log.Printf("Error marshalling topic-subscription: %v", err)
-		return
-	}
-	op.Broadcast(context.Background(), data)
-	log.Println("Leader: Broadcasted topic-subscription structure to all nodes")
-}
-*/

--- a/broadcast/broadcast_struct.go
+++ b/broadcast/broadcast_struct.go
@@ -114,9 +114,9 @@ func StartDistributor(ctx context.Context, op *hedge.Op, client *spanner.Client)
 		log.Println("Leader: Distributor ticker stopped.")
 	}()
 
-	// Perform an initial broadcast of all topic-subscription structures only if this instance is the leader
+	// Perform an initial broadcast of all topic-subscription structures
 	if hasLock, _ := op.HasLock(); hasLock {
-		log.Println("Leader: Startup detected. Broadcasting full topic-subscription data.")
+		log.Println("Leader: Startup, broadcasting topic-subscription structure.")
 		fetchAndBroadcast(ctx, op, client, &lastChecked, &lastBroadcasted, true) // run during startup
 	} else {
 		log.Println("Follower: Skipping startup broadcast.")


### PR DESCRIPTION
1. on startup, it fetches the topic-subscription structure while ignoring the updatedAt column which will guarantee that the followers will receive the latest structure even after a crash.
2. After startup, it will only fetch new updates where updatedat>lastchecked to prevent redundant broadcasts.