### PR TITLE
Added close(stopExtension) after message processing is complete.

### DIFF
--- a/server.go
+++ b/server.go
@@ -103,6 +103,9 @@ func (s *server) Subscribe(in *pb.SubscribeRequest, stream pb.PubSubService_Subs
 
 	glog.Infof("[Subscribe] Starting subscription stream for ID: %s", in.Subscription)
 
+	// Track last message count to avoid duplicate logs
+	lastMessageCount := 0
+
 	// Continuous loop to stream messages
 	for {
 		select {
@@ -126,7 +129,11 @@ func (s *server) Subscribe(in *pb.SubscribeRequest, stream pb.PubSubService_Subs
 				continue
 			}
 
-			glog.Infof("[Subscribe] Found %d messages for topic %s", len(messages), in.Topic)
+			// Only log if the number of messages has changed
+			if len(messages) != lastMessageCount {
+				glog.Infof("[Subscribe] Found %d messages for topic %s", len(messages), in.Topic)
+				lastMessageCount = len(messages)
+			}
 
 			// Process each message
 			for _, message := range messages {

--- a/testclient/testclient.go
+++ b/testclient/testclient.go
@@ -13,6 +13,8 @@ import (
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/codes"
 )
 
 var (
@@ -143,12 +145,13 @@ func main() {
 					case <-processingDone:
 						ticker.Stop()
 						glog.Infof("[Processing] Completed message %v processing after %d seconds", rec.Id, *processingTime)
+						close(stopExtension) // Stop the visibility extension goroutine
 						break
 					}
 				}
 			}
 
-
+			// Acknowledge the message
 			ackres, err := c.Acknowledge(context.Background(), &pb.AcknowledgeRequest{Id: rec.Id, Subscription: sub})
 			if err != nil {
 				log.Fatalf("Acknowledge failed: %v", err)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6046dc46-2c73-4b0c-b178-a3c538a3046b)

did some testing and looking at the behavior, there seems to be an issue where the client is continuously requesting visibility timeout extensions even after the message has been processed. that's why i added close(stopExtension) at testclient.go hoping this could fix the issue